### PR TITLE
fix: response types for interaction

### DIFF
--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -29,8 +29,6 @@ export enum InteractionType {
  */
 export enum InteractionResponseType {
     PONG = 1,
-    ACKNOWLEDGE = 2,
-    CHANNEL_MESSAGE = 3,
     CHANNEL_MESSAGE_WITH_SOURCE = 4,
     DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
 }


### PR DESCRIPTION
**Please describe the changes this pull request makes:**
Some response types were deprecated and I updated them (`Acknowledge` and `ChannelMessage`)